### PR TITLE
benchmarks/pta/brp-pta: added missing parameter 'TIME_BOUND'.

### DIFF
--- a/benchmarks/pta/brp-pta/index.json
+++ b/benchmarks/pta/brp-pta/index.json
@@ -40,6 +40,12 @@
 			"kind": "open",
 			"description": "Transmission delay",
 			"type": "non-negative integer"
+		},
+		{
+			"name": "TIME_BOUND",
+			"kind": "open",
+			"description": "Time bound for properties",
+			"type": "non-negative integer"
 		}
 	],
 	"files": [


### PR DESCRIPTION
The parameter was listed in the 'open-parameter-values' entries, but not in "parameters".