### PR TITLE
benchmarks/pta/firewire_abst-pta: Removed multiple occurrences of parameter values

### DIFF
--- a/benchmarks/pta/firewire_abst-pta/index.json
+++ b/benchmarks/pta/firewire_abst-pta/index.json
@@ -136,18 +136,6 @@
 						},
 						{
 							"name": "T",
-							"value": 5000
-						}
-					]
-				},
-				{
-					"values": [
-						{
-							"name": "delay",
-							"value": 30
-						},
-						{
-							"name": "T",
 							"value": 10000
 						}
 					],
@@ -227,18 +215,6 @@
 						{
 							"note": "mcsta",
 							"number": 7670
-						}
-					]
-				},
-				{
-					"values": [
-						{
-							"name": "delay",
-							"value": 360
-						},
-						{
-							"name": "T",
-							"value": 5000
 						}
 					]
 				},


### PR DESCRIPTION
For some reason, the valuations delay=30,T=5000 and delay=360,T=5000 appeared multiple times in the meta data of firewire_abst-pta.