### PR TITLE
benchmarks/pacman.props: resolve clash between label and property name

### DIFF
--- a/benchmarks/mdp/pacman/pacman.props
+++ b/benchmarks/mdp/pacman/pacman.props
@@ -1,1 +1,1 @@
-"crash": Pmin=? [F "crash"]
+"Crash": Pmin=? [F "crash"]


### PR DESCRIPTION
PRISM complains that the "crash" label is reused as a propert name. Rename the property.