### PR TITLE
Name clash fix

### DIFF
--- a/benchmarks/dtmc/haddad-monmege/haddad-monmege.jani
+++ b/benchmarks/dtmc/haddad-monmege/haddad-monmege.jani
@@ -8,6 +8,7 @@
                         {
                             "assignments": [
                                 {
+                                    "comment": "x <- (N - 1)",
                                     "ref": "x",
                                     "value": {
                                         "left": "N",
@@ -25,6 +26,7 @@
                         {
                             "assignments": [
                                 {
+                                    "comment": "x <- (N + 1)",
                                     "ref": "x",
                                     "value": {
                                         "left": "N",
@@ -59,6 +61,7 @@
                         {
                             "assignments": [
                                 {
+                                    "comment": "x <- (x - 1)",
                                     "ref": "x",
                                     "value": {
                                         "left": "x",
@@ -76,6 +79,7 @@
                         {
                             "assignments": [
                                 {
+                                    "comment": "x <- N",
                                     "ref": "x",
                                     "value": "N"
                                 }
@@ -83,11 +87,7 @@
                             "location": "l",
                             "probability": {
                                 "comment": "(1 - 1/2)",
-                                "exp": {
-                                    "left": 1,
-                                    "op": "-",
-                                    "right": 0.5
-                                }
+                                "exp": 0.5
                             }
                         }
                     ],
@@ -114,6 +114,7 @@
                         {
                             "assignments": [
                                 {
+                                    "comment": "x <- (x + 1)",
                                     "ref": "x",
                                     "value": {
                                         "left": "x",
@@ -131,6 +132,7 @@
                         {
                             "assignments": [
                                 {
+                                    "comment": "x <- N",
                                     "ref": "x",
                                     "value": "N"
                                 }
@@ -138,11 +140,7 @@
                             "location": "l",
                             "probability": {
                                 "comment": "(1 - 1/2)",
-                                "exp": {
-                                    "left": 1,
-                                    "op": "-",
-                                    "right": 0.5
-                                }
+                                "exp": 0.5
                             }
                         }
                     ],
@@ -171,7 +169,6 @@
                 {
                     "destinations": [
                         {
-                            "assignments": [],
                             "location": "l"
                         }
                     ],
@@ -206,7 +203,8 @@
                     "name": "l",
                     "transient-values": [
                         {
-                            "ref": "target",
+                            "comment": "Target <- (x = 0)",
+                            "ref": "Target",
                             "value": {
                                 "left": "x",
                                 "op": "=",
@@ -214,7 +212,8 @@
                             }
                         },
                         {
-                            "ref": "done",
+                            "comment": "Done <- ((x = 0) | (x = (2 * N)))",
+                            "ref": "Done",
                             "value": {
                                 "left": {
                                     "left": "x",
@@ -272,7 +271,7 @@
                     "exp": {
                         "left": true,
                         "op": "U",
-                        "right": "target"
+                        "right": "Target"
                     },
                     "op": "Pmin"
                 }
@@ -292,7 +291,7 @@
                     ],
                     "exp": 1,
                     "op": "Emin",
-                    "reach": "done"
+                    "reach": "Done"
                 }
             },
             "name": "exp_steps"
@@ -312,13 +311,13 @@
     "variables": [
         {
             "initial-value": false,
-            "name": "target",
+            "name": "Target",
             "transient": true,
             "type": "bool"
         },
         {
             "initial-value": false,
-            "name": "done",
+            "name": "Done",
             "transient": true,
             "type": "bool"
         },

--- a/benchmarks/dtmc/haddad-monmege/haddad-monmege.pm
+++ b/benchmarks/dtmc/haddad-monmege/haddad-monmege.pm
@@ -15,5 +15,5 @@ module main
 	[] x=0 | x=2*N -> 1 : true;
 endmodule
 
-label "target" = x=0;
-label "done" = x=0 | x=2*N;
+label "Target" = x=0;
+label "Done" = x=0 | x=2*N;

--- a/benchmarks/dtmc/haddad-monmege/haddad-monmege.prctl
+++ b/benchmarks/dtmc/haddad-monmege/haddad-monmege.prctl
@@ -1,5 +1,5 @@
 // Probability to reach the target state
-"target": P=? [F "target"];
+"target": P=? [F "Target"];
 
 // Expected number of steps to reach the target or the sink state
-"exp_steps": T=? [F "done"];
+"exp_steps": T=? [F "Done"];

--- a/benchmarks/dtmc/haddad-monmege/index.json
+++ b/benchmarks/dtmc/haddad-monmege/index.json
@@ -54,7 +54,7 @@
 				"tool": "Storm-conv",
 				"version": "1.2.4 (dev)",
 				"url": "http://www.stormchecker.org",
-				"command": "storm-conv --prism haddad-monmege.pm --tojani haddad-monmege.jani --prop haddad-monmege.prctl --globalvars --standard-compliant"
+				"command": "storm-conv --prism haddad-monmege.pm --tojani haddad-monmege.jani --prop haddad-monmege.prctl --globalvars"
 			},
 			"file-parameter-values": [],
 			"open-parameter-values": [

--- a/benchmarks/mdp/pacman/pacman.jani
+++ b/benchmarks/mdp/pacman/pacman.jani
@@ -642,8 +642,8 @@
                     "name": "l",
                     "transient-values": [
                         {
-                            "comment": "crash <- (((xP = xG0) & (yP = yG0)) | ((xP = xG1) & (yP = yG1)))",
-                            "ref": "crash",
+                            "comment": "Crash <- (((xP = xG0) & (yP = yG0)) | ((xP = xG1) & (yP = yG1)))",
+                            "ref": "Crash",
                             "value": {
                                 "left": {
                                     "left": {
@@ -39959,7 +39959,7 @@
                     "exp": {
                         "left": true,
                         "op": "U",
-                        "right": "crash"
+                        "right": "Crash"
                     },
                     "op": "Pmin"
                 }
@@ -40073,7 +40073,7 @@
     "variables": [
         {
             "initial-value": false,
-            "name": "crash",
+            "name": "Crash",
             "transient": true,
             "type": "bool"
         },

--- a/benchmarks/mdp/pacman/pacman.nm
+++ b/benchmarks/mdp/pacman/pacman.nm
@@ -1101,6 +1101,6 @@ module pacman
 endmodule
 
 //CRASH
-label "crash" = (xP = xG0 & yP = yG0) | (xP = xG1 & yP = yG1);
-//label "safe" = deactive0 & deactive1;
+label "Crash" = (xP = xG0 & yP = yG0) | (xP = xG1 & yP = yG1);
+//label "Safe" = deactive0 & deactive1;
 

--- a/benchmarks/mdp/pacman/pacman.props
+++ b/benchmarks/mdp/pacman/pacman.props
@@ -1,1 +1,1 @@
-"crash": Pmin=? [F "crash"]
+"crash": Pmin=? [F "Crash"]


### PR DESCRIPTION
This pull request fixes two name clashes of property-names and label-names in PRISM files as pointed out by @kleinj .
This renames the label (while PR #37  renames the property).