### PR TITLE
Fix broken header links

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
 <h1>Quantitative Modelling and Verification</h1>
 <div class="belowh1">
-	<a href="#qvbs">Benchmark Set</a> &nbsp;|&nbsp; <a href="#qcomp">Competition</a>
+	<a href="/benchmarks">Benchmark Set</a> &nbsp;|&nbsp; <a href="/competition/2020">Competition</a>
 </div>
 <p>
 	<b>qcomp.org</b> is the home of the <b><a href="#qvbs">QVBS</a></b>: the Quantitative Verification Benchmark Set, and of <b><a href="#qcomp">QComp</a></b>: the Comparison of Tools for the Analysis of Quantitative Formal Models.


### PR DESCRIPTION
The 'Benchmark Set' and 'Competition' links are broken on the homepage. This PR fixes those links.