### PR TITLE
Fixed type error of power expressions in PRISM->JANI conversion.

### DIFF
--- a/benchmarks/pta/csma-pta/csma-pta.jani
+++ b/benchmarks/pta/csma-pta/csma-pta.jani
@@ -47988,9 +47988,12 @@
                                 "op": "=",
                                 "right": {
                                     "left": {
-                                        "left": 2,
-                                        "op": "pow",
-                                        "right": "cd1"
+                                        "exp": {
+                                            "left": 2,
+                                            "op": "pow",
+                                            "right": "cd1"
+                                        },
+                                        "op": "trc"
                                     },
                                     "op": "*",
                                     "right": 52
@@ -48104,9 +48107,12 @@
                                 "op": "=",
                                 "right": {
                                     "left": {
-                                        "left": 2,
-                                        "op": "pow",
-                                        "right": "cd1"
+                                        "exp": {
+                                            "left": 2,
+                                            "op": "pow",
+                                            "right": "cd1"
+                                        },
+                                        "op": "trc"
                                     },
                                     "op": "*",
                                     "right": 52
@@ -48239,9 +48245,12 @@
                                 "op": "=",
                                 "right": {
                                     "left": {
-                                        "left": 2,
-                                        "op": "pow",
-                                        "right": "cd1"
+                                        "exp": {
+                                            "left": 2,
+                                            "op": "pow",
+                                            "right": "cd1"
+                                        },
+                                        "op": "trc"
                                     },
                                     "op": "*",
                                     "right": 52
@@ -48274,9 +48283,12 @@
                                         "op": "≤",
                                         "right": {
                                             "left": {
-                                                "left": 2,
-                                                "op": "pow",
-                                                "right": "cd1"
+                                                "exp": {
+                                                    "left": 2,
+                                                    "op": "pow",
+                                                    "right": "cd1"
+                                                },
+                                                "op": "trc"
                                             },
                                             "op": "*",
                                             "right": 52
@@ -95693,9 +95705,12 @@
                                 "op": "=",
                                 "right": {
                                     "left": {
-                                        "left": 2,
-                                        "op": "pow",
-                                        "right": "cd2"
+                                        "exp": {
+                                            "left": 2,
+                                            "op": "pow",
+                                            "right": "cd2"
+                                        },
+                                        "op": "trc"
                                     },
                                     "op": "*",
                                     "right": 52
@@ -95809,9 +95824,12 @@
                                 "op": "=",
                                 "right": {
                                     "left": {
-                                        "left": 2,
-                                        "op": "pow",
-                                        "right": "cd2"
+                                        "exp": {
+                                            "left": 2,
+                                            "op": "pow",
+                                            "right": "cd2"
+                                        },
+                                        "op": "trc"
                                     },
                                     "op": "*",
                                     "right": 52
@@ -95944,9 +95962,12 @@
                                 "op": "=",
                                 "right": {
                                     "left": {
-                                        "left": 2,
-                                        "op": "pow",
-                                        "right": "cd2"
+                                        "exp": {
+                                            "left": 2,
+                                            "op": "pow",
+                                            "right": "cd2"
+                                        },
+                                        "op": "trc"
                                     },
                                     "op": "*",
                                     "right": 52
@@ -95979,9 +96000,12 @@
                                         "op": "≤",
                                         "right": {
                                             "left": {
-                                                "left": 2,
-                                                "op": "pow",
-                                                "right": "cd2"
+                                                "exp": {
+                                                    "left": 2,
+                                                    "op": "pow",
+                                                    "right": "cd2"
+                                                },
+                                                "op": "trc"
                                             },
                                             "op": "*",
                                             "right": 52
@@ -96071,9 +96095,12 @@
             "type": "int",
             "value": {
                 "left": {
-                    "left": 2,
-                    "op": "pow",
-                    "right": "K"
+                    "exp": {
+                        "left": 2,
+                        "op": "pow",
+                        "right": "K"
+                    },
+                    "op": "trc"
                 },
                 "op": "-",
                 "right": 1
@@ -96256,13 +96283,13 @@
             "type": "bool"
         },
         {
-            "initial-value": 0.0,
+            "initial-value": 0,
             "name": "time",
             "transient": true,
             "type": "real"
         },
         {
-            "initial-value": 0.0,
+            "initial-value": 0,
             "name": "collisions",
             "transient": true,
             "type": "real"
@@ -96292,12 +96319,12 @@
             }
         },
         {
-            "initial-value": 0.0,
+            "initial-value": 0,
             "name": "y1",
             "type": "clock"
         },
         {
-            "initial-value": 0.0,
+            "initial-value": 0,
             "name": "y2",
             "type": "clock"
         },
@@ -96322,7 +96349,7 @@
             }
         },
         {
-            "initial-value": 0.0,
+            "initial-value": 0,
             "name": "x1",
             "type": "clock"
         },
@@ -96347,7 +96374,7 @@
             }
         },
         {
-            "initial-value": 0.0,
+            "initial-value": 0,
             "name": "x2",
             "type": "clock"
         }

--- a/benchmarks/pta/csma-pta/index.json
+++ b/benchmarks/pta/csma-pta/index.json
@@ -3,13 +3,18 @@
 	"short": "csma-pta",
 	"type": "pta",
 	"original": "PRISM",
-	"version": 1,
-	"date": "2018-10-11",
+	"version": 2,
+	"date": "2021-02-17",
 	"version-history": [
 		{
 			"date": "2018-10-11",
 			"notes": "Initial version.",
 			"version": 1
+		},
+		{
+			"date": "2021-02-17",
+			"notes": "Fixed type error of power expressions in JANI code.",
+			"version": 2
 		}
 	],
 	"author": "IEEE",
@@ -55,7 +60,7 @@
 			],
 			"conversion": {
 				"tool": "Storm-conv",
-				"version": "1.2.4 (dev)",
+				"version": "1.6.4 (dev)",
 				"url": "http://www.stormchecker.org",
 				"command": "storm-conv --prism csma-pta.prism --tojani csma-pta.jani --prop csma-pta.props --globalvars"
 			},

--- a/benchmarks/pta/csma_abst-pta/csma_abst-pta.jani
+++ b/benchmarks/pta/csma_abst-pta/csma_abst-pta.jani
@@ -1230,9 +1230,12 @@
                                 "op": "=",
                                 "right": {
                                     "left": {
-                                        "left": 2,
-                                        "op": "pow",
-                                        "right": "cd1"
+                                        "exp": {
+                                            "left": 2,
+                                            "op": "pow",
+                                            "right": "cd1"
+                                        },
+                                        "op": "trc"
                                     },
                                     "op": "*",
                                     "right": 52
@@ -1400,9 +1403,12 @@
                                 "op": "=",
                                 "right": {
                                     "left": {
-                                        "left": 2,
-                                        "op": "pow",
-                                        "right": "cd1"
+                                        "exp": {
+                                            "left": 2,
+                                            "op": "pow",
+                                            "right": "cd1"
+                                        },
+                                        "op": "trc"
                                     },
                                     "op": "*",
                                     "right": 52
@@ -1435,9 +1441,12 @@
                                         "op": "≤",
                                         "right": {
                                             "left": {
-                                                "left": 2,
-                                                "op": "pow",
-                                                "right": "cd1"
+                                                "exp": {
+                                                    "left": 2,
+                                                    "op": "pow",
+                                                    "right": "cd1"
+                                                },
+                                                "op": "trc"
                                             },
                                             "op": "*",
                                             "right": 52
@@ -2360,9 +2369,12 @@
                                 "op": "=",
                                 "right": {
                                     "left": {
-                                        "left": 2,
-                                        "op": "pow",
-                                        "right": "cd2"
+                                        "exp": {
+                                            "left": 2,
+                                            "op": "pow",
+                                            "right": "cd2"
+                                        },
+                                        "op": "trc"
                                     },
                                     "op": "*",
                                     "right": 52
@@ -2530,9 +2542,12 @@
                                 "op": "=",
                                 "right": {
                                     "left": {
-                                        "left": 2,
-                                        "op": "pow",
-                                        "right": "cd2"
+                                        "exp": {
+                                            "left": 2,
+                                            "op": "pow",
+                                            "right": "cd2"
+                                        },
+                                        "op": "trc"
                                     },
                                     "op": "*",
                                     "right": 52
@@ -2565,9 +2580,12 @@
                                         "op": "≤",
                                         "right": {
                                             "left": {
-                                                "left": 2,
-                                                "op": "pow",
-                                                "right": "cd2"
+                                                "exp": {
+                                                    "left": 2,
+                                                    "op": "pow",
+                                                    "right": "cd2"
+                                                },
+                                                "op": "trc"
                                             },
                                             "op": "*",
                                             "right": 52
@@ -2822,7 +2840,7 @@
             }
         },
         {
-            "initial-value": 0.0,
+            "initial-value": 0,
             "name": "y",
             "type": "clock"
         },
@@ -2847,7 +2865,7 @@
             }
         },
         {
-            "initial-value": 0.0,
+            "initial-value": 0,
             "name": "x1",
             "type": "clock"
         },
@@ -2872,7 +2890,7 @@
             }
         },
         {
-            "initial-value": 0.0,
+            "initial-value": 0,
             "name": "x2",
             "type": "clock"
         }

--- a/benchmarks/pta/csma_abst-pta/index.json
+++ b/benchmarks/pta/csma_abst-pta/index.json
@@ -3,13 +3,17 @@
 	"short": "csma_abst-pta",
 	"type": "pta",
 	"original": "PRISM",
-	"version": 1,
-	"date": "2018-10-11",
+	"version": 2,
+	"date": "2021-02-17",
 	"version-history": [
 		{
 			"date": "2018-10-11",
 			"notes": "Initial version.",
 			"version": 1
+		},
+		{
+			"date": "2021-02-17",
+			"notes": "Fixed type error of power expressions in JANI code."
 		}
 	],
 	"author": "IEEE",
@@ -65,7 +69,7 @@
 			],
 			"conversion": {
 				"tool": "Storm-conv",
-				"version": "1.2.4 (dev)",
+				"version": "1.6.4 (dev)",
 				"url": "http://www.stormchecker.org",
 				"command": "storm-conv --prism csma_abst-pta.prism --tojani csma_abst-pta.jani --prop csma_abst-pta.props --globalvars"
 			},


### PR DESCRIPTION
This PR fixes issue #103 which was introduced due to a bug in Storm.
The issue affected only the two models `csma-pta` and `csma_abst-pta`.